### PR TITLE
Convert README links from rel to abs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ We also recommend updating the automated tests *before* updating any code (see [
 Development](https://en.wikipedia.org/wiki/Test-driven_development)). That means you add or update a test case, 
 verify that it's failing with a clear error message, and *then* make the code changes to get that test to pass. This 
 ensures the tests stay up to date and verify all the functionality in this Module, including whatever new 
-functionality you're adding in your contribution. Check out the [tests](/tests) folder for instructions on running the 
+functionality you're adding in your contribution. Check out the [tests](https://github.com/gruntwork-io/terraform-google-consul/tests) folder for instructions on running the 
 automated tests. 
 
 ## Update the code
@@ -83,4 +83,4 @@ to include the following:
 ## Merge and release   
 
 The maintainers for this repo will review your code and provide feedback. If everything looks good, they will merge the
-code and release a new version, which you'll be able to find in the [releases page](../../releases).
+code and release a new version, which you'll be able to find in the [releases page](https://github.com/gruntwork-io/terraform-google-consul/releases).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Contributions are very welcome! Check out the [Contribution Guidelines](https://
 ## How is this Terraform Module versioned?
 
 This Terraform Module follows the principles of [Semantic Versioning](http://semver.org/). You can find each new release, 
-along with the changelog, in the [Releases Page](https://github.com/gruntwork-io/terraform-google-consul/../../releases). 
+along with the changelog, in the [Releases Page](https://github.com/gruntwork-io/terraform-google-consul/releases). 
 
 During initial development, the major version will be 0 (e.g., `0.x.y`), which indicates the code does not yet have a 
 stable API. Once we hit `1.0.0`, we will make every effort to maintain a backwards compatible API and use the MAJOR, 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ of server nodes, which are responsible for being part of the [consensus
 quorum](https://www.consul.io/docs/internals/consensus.html), and a larger number of client nodes, which you typically 
 run alongside your apps:
 
-![Consul architecture](/_docs/architecture.png)
+![Consul architecture](https://github.com/gruntwork-io/terraform-google-consul/_docs/architecture.png)
 
 
 
@@ -15,27 +15,27 @@ run alongside your apps:
 
 Each Module has the following folder structure:
 
-* [modules](/modules): This folder contains the reusable code for this Module, broken down into one or more submodules.
-* [examples](/examples): This folder contains examples of how to use the submodules.
-* [test](/test): Automated tests for the submodules and examples.
+* [modules](https://github.com/gruntwork-io/terraform-google-consul/modules): This folder contains the reusable code for this Module, broken down into one or more submodules.
+* [examples](https://github.com/gruntwork-io/terraform-google-consul/examples): This folder contains examples of how to use the submodules.
+* [test](https://github.com/gruntwork-io/terraform-google-consul/test): Automated tests for the submodules and examples.
 
 To deploy Consul servers using this Module:
 
-1. Create a Consul Image using a Packer template that references the [install-consul module](/modules/install-consul).
-   Here is an [example Packer template](/examples/consul-image#quick-start). Note that Google Cloud does not support custom
+1. Create a Consul Image using a Packer template that references the [install-consul module](https://github.com/gruntwork-io/terraform-google-consul/modules/install-consul).
+   Here is an [example Packer template](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-image#quick-start). Note that Google Cloud does not support custom
    public Images so you must build this Packer template on your own to proceed.
    
-1. Deploy that Image across a Compute Instance Group using the Terraform [consul-cluster module](/modules/consul-cluster) 
-   and execute the [run-consul script](/modules/run-consul) with the `--server` flag during boot on each 
+1. Deploy that Image across a Compute Instance Group using the Terraform [consul-cluster module](https://github.com/gruntwork-io/terraform-google-consul/modules/consul-cluster) 
+   and execute the [run-consul script](https://github.com/gruntwork-io/terraform-google-consul/modules/run-consul) with the `--server` flag during boot on each 
    Instance in the Compute Instance Group to form the Consul cluster. Here is [an example Terraform 
-   configuration](/examples/consul-cluster#quick-start) to provision a Consul cluster.
+   configuration](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-cluster#quick-start) to provision a Consul cluster.
 
 To deploy Consul clients using this Module:
  
-1. Use the [install-consul module](/modules/install-consul) to install Consul alongside your application code.
-1. Before booting your app, execute the [run-consul script](/modules/run-consul) with `--client` flag.
+1. Use the [install-consul module](https://github.com/gruntwork-io/terraform-google-consul/modules/install-consul) to install Consul alongside your application code.
+1. Before booting your app, execute the [run-consul script](https://github.com/gruntwork-io/terraform-google-consul/modules/run-consul) with `--client` flag.
 1. Your app can now usr the local Consul agent for service discovery and key/value storage. 
-1. Optionally, you can use the [install-dnsmasq module](/modules/install-dnsmasq) to configure Consul as the DNS for a
+1. Optionally, you can use the [install-dnsmasq module](https://github.com/gruntwork-io/terraform-google-consul/modules/install-dnsmasq) to configure Consul as the DNS for a
    specific domain (e.g. `.consul`) so that URLs such as `foo.service.consul` resolve automatically to the IP 
    address(es) for a service `foo` registered in Consul (all other domain names will be continue to resolve using the
    default resolver on the OS).
@@ -72,30 +72,30 @@ Gruntwork can help with:
 
 ## Code included in this Terraform Module:
 
-* [install-consul](/modules/install-consul): This module installs Consul using a [Packer](https://www.packer.io/)
+* [install-consul](https://github.com/gruntwork-io/terraform-google-consul/modules/install-consul): This module installs Consul using a [Packer](https://www.packer.io/)
   template to create a Consul [Custom Image](https://cloud.google.com/compute/docs/images).
 
-* [consul-cluster](/modules/consul-cluster): The module includes Terraform code to deploy a Consul Image across a [Managed
+* [consul-cluster](https://github.com/gruntwork-io/terraform-google-consul/modules/consul-cluster): The module includes Terraform code to deploy a Consul Image across a [Managed
   Compute Instance Group](https://cloud.google.com/compute/docs/instance-groups/). 
   
-* [run-consul](/modules/run-consul): This module includes the scripts to configure and run Consul. It is used
+* [run-consul](https://github.com/gruntwork-io/terraform-google-consul/modules/run-consul): This module includes the scripts to configure and run Consul. It is used
   by the above Packer module at build-time to set configurations, and by the Terraform module at runtime 
   with the Instance's [Startup Script](https://cloud.google.com/compute/docs/startupscript) to create the cluster.
 
-* [install-dnsmasq module](/modules/install-dnsmasq): Install [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html)
+* [install-dnsmasq module](https://github.com/gruntwork-io/terraform-google-consul/modules/install-dnsmasq): Install [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html)
   and configure it to forward requests for a specific domain to Consul. This allows you to use Consul as a DNS server
   for URLs such as `foo.service.consul`.
 
 ## How do I contribute to this Terraform Module?
 
-Contributions are very welcome! Check out the [Contribution Guidelines](/CONTRIBUTING.md) for instructions.
+Contributions are very welcome! Check out the [Contribution Guidelines](https://github.com/gruntwork-io/terraform-google-consul/CONTRIBUTING.md) for instructions.
 
 
 
 ## How is this Terraform Module versioned?
 
 This Terraform Module follows the principles of [Semantic Versioning](http://semver.org/). You can find each new release, 
-along with the changelog, in the [Releases Page](../../releases). 
+along with the changelog, in the [Releases Page](https://github.com/gruntwork-io/terraform-google-consul/../../releases). 
 
 During initial development, the major version will be 0 (e.g., `0.x.y`), which indicates the code does not yet have a 
 stable API. Once we hit `1.0.0`, we will make every effort to maintain a backwards compatible API and use the MAJOR, 
@@ -105,6 +105,6 @@ MINOR, and PATCH versions on each release to indicate any incompatibilities.
 
 ## License
 
-This code is released under the Apache 2.0 License. Please see [LICENSE](/LICENSE) and [NOTICE](/NOTICE) for more 
+This code is released under the Apache 2.0 License. Please see [LICENSE](https://github.com/gruntwork-io/terraform-google-consul/LICENSE) and [NOTICE](https://github.com/gruntwork-io/terraform-google-consul/NOTICE) for more 
 details.
 

--- a/examples/consul-examples-helper/README.md
+++ b/examples/consul-examples-helper/README.md
@@ -1,7 +1,7 @@
 # Consul Examples Helper
 
 This folder contains a helper script called `consul-examples-helper.sh` for working with the 
-[consul-cluster example](/examples/consul-cluster). After running `terraform apply` on the example, if you run 
+[consul-cluster example](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-cluster). After running `terraform apply` on the example, if you run 
 `consul-examples-helper.sh`, it will automatically:
 
 1. Wait for the Consul server cluster to come up.

--- a/examples/consul-image/README.md
+++ b/examples/consul-image/README.md
@@ -1,7 +1,7 @@
 # Consul Google Image
 
-This folder shows an example of how to use the [install-consul](/modules/install-consul) and 
-[install-dnsmasq](/modules/install-dnsmasq) modules with [Packer](https://www.packer.io/) to create [Custom Images](
+This folder shows an example of how to use the [install-consul](https://github.com/gruntwork-io/terraform-google-consul/modules/install-consul) and 
+[install-dnsmasq](https://github.com/gruntwork-io/terraform-google-consul/modules/install-dnsmasq) modules with [Packer](https://www.packer.io/) to create [Custom Images](
 https://cloud.google.com/compute/docs/images) that have Consul and Dnsmasq installed on 
 top of Ubuntu 16.04 LTS. At this time, Ubuntu 16.04 LTS is the only supported Linux distribution.
 
@@ -9,10 +9,10 @@ These Images will have [Consul](https://www.consul.io/) installed and configured
 boot-up. They also have [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) installed and configured to use 
 Consul for DNS lookups of the `.consul` domain (e.g. `foo.service.consul`) (see [registering 
 services](https://www.consul.io/intro/getting-started/services.html) for instructions on how to register your services
-in Consul). To see how to deploy this Image, check out the [consul-cluster example](/examples/consul-cluster). 
+in Consul). To see how to deploy this Image, check out the [consul-cluster example](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-cluster). 
 
 For more info on Consul installation and configuration, check out the 
-[install-consul](/modules/install-consul) and [install-dnsmasq](/modules/install-dnsmasq) documentation.
+[install-consul](https://github.com/gruntwork-io/terraform-google-consul/modules/install-consul) and [install-dnsmasq](https://github.com/gruntwork-io/terraform-google-consul/modules/install-dnsmasq) documentation.
 
 
 
@@ -28,7 +28,7 @@ To build the Consul Image:
 1. Run `packer build consul.json`.
 
 When the build finishes, it will output the ID of the new Custom Image. To see how to deploy one of these Images, check
-out the  [consul-cluster example](/examples/consul-cluster).
+out the  [consul-cluster example](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-cluster).
 
 
 
@@ -73,7 +73,7 @@ Your code should look more like this:
 ```
 
 You should replace `<MODULE_VERSION>` in the code above with the version of this Module that you want to use (see
-the [Releases Page](../../releases) for all available versions). That's because for production usage, you should always
+the [Releases Page](https://github.com/gruntwork-io/terraform-google-consul/releases) for all available versions). That's because for production usage, you should always
 use a fixed, known version of this Module, downloaded from the official Git repo. On the other hand, when you're 
 just experimenting with the Module, it's OK to use a local checkout of the Module, uploaded from your own 
 computer.

--- a/examples/root/README.md
+++ b/examples/root/README.md
@@ -1,20 +1,20 @@
 # Consul Cluster Example
 
-This folder shows an example of Terraform code that uses the [consul-cluster](/modules/consul-cluster) module to deploy 
+This folder shows an example of Terraform code that uses the [consul-cluster](https://github.com/gruntwork-io/terraform-google-consul/modules/consul-cluster) module to deploy 
 a [Consul](https://www.consul.io/) cluster in [Google Cloud](https://cloud.google.com/). The cluster consists of two 
 Compute Instance Groups: one with Consul server nodes, which are responsible for being part of the [consensus 
 quorum](https://www.consul.io/docs/internals/consensus.html), and one with client nodes, which  would typically run 
 alongside your apps:
 
-![Consul architecture](/_docs/architecture.png)
+![Consul architecture](https://github.com/gruntwork-io/terraform-google-consul/_docs/architecture.png)
 
 You will need to create a [Custom Image](https://cloud.google.com/compute/docs/images) 
-that has Consul installed, which you can do using the [consul-image example](/examples/consul-image)). Note that to keep 
+that has Consul installed, which you can do using the [consul-image example](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-image)). Note that to keep 
 this example simple, both the server Instance Group and client Instance Group are running the exact same Custom Image. 
 In real-world usage, you'd probably have multiple client Instance Groups, and each of those Instance Groups would run a
 different Custom Image that has the Consul agent installed alongside your apps.
 
-For more info on how the Consul cluster works, check out the [consul-cluster](/modules/consul-cluster) documentation.
+For more info on how the Consul cluster works, check out the [consul-cluster](https://github.com/gruntwork-io/terraform-google-consul/modules/consul-cluster) documentation.
 
 
 
@@ -23,7 +23,7 @@ For more info on how the Consul cluster works, check out the [consul-cluster](/m
 To deploy a Consul Cluster:
 
 1. `git clone` this repo to your computer.
-1. Build a Consul Custom Image. See the [consul-image example](/examples/consul-image) documentation for instructions. 
+1. Build a Consul Custom Image. See the [consul-image example](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-image) documentation for instructions. 
    Make sure to note down the ID of the Custom Image.
 1. Install [Terraform](https://www.terraform.io/).
 1. Open `vars.tf` and fill in any other variables that don't have a default, including putting your Custom Image ID into

--- a/modules/consul-cluster/README.md
+++ b/modules/consul-cluster/README.md
@@ -3,7 +3,7 @@
 This folder contains a [Terraform](https://www.terraform.io/) module to deploy a 
 [Consul](https://www.consul.io/) cluster in [GCP](https://cloud.google.com/) on top of a Zonal Manged Instance
 Group. This module is designed to deploy a [Google Image](https://cloud.google.com/compute/docs/images) that has Consul
-installed via the [install-consul](/modules/install-consul) module in this Module.
+installed via the [install-consul](https://github.com/gruntwork-io/terraform-google-consul/modules/install-consul) module in this Module.
 
 
 
@@ -45,16 +45,16 @@ Note the following parameters:
 
 * `source_image`: Use this parameter to specify the name of the Consul [Google Image](https://cloud.google.com/compute/docs/images)
   to deploy on each server in the cluster. You should install Consul in this Image using the scripts in the 
-  [install-consul](/modules/install-consul) module.
+  [install-consul](https://github.com/gruntwork-io/terraform-google-consul/modules/install-consul) module.
   
 * `startup_script`: Use this parameter to specify a [Startup Script](https://cloud.google.com/compute/docs/startupscript) script that each
-  server will run during boot. This is where you can use the [run-consul script](/modules/run-consul) to configure and 
-  run Consul. The `run-consul` script is one of the scripts installed by the [install-consul](/modules/install-consul) 
+  server will run during boot. This is where you can use the [run-consul script](https://github.com/gruntwork-io/terraform-google-consul/modules/run-consul) to configure and 
+  run Consul. The `run-consul` script is one of the scripts installed by the [install-consul](https://github.com/gruntwork-io/terraform-google-consul/modules/install-consul) 
   module. 
 
 You can find the other parameters in [vars.tf](vars.tf).
 
-Check out the [consul-cluster example](/examples/consul-cluster) for fully-working sample code. 
+Check out the [consul-cluster example](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-cluster) for fully-working sample code. 
 
 
 
@@ -65,12 +65,12 @@ Check out the [consul-cluster example](/examples/consul-cluster) for fully-worki
 
 If you want to connect to the cluster from your own computer, the easiest way is to use the [HTTP 
 API](https://www.consul.io/docs/agent/http.html). Note that this only works if the Consul cluster is running with 
-`assign_public_ip_addresses` set to `true` (as in the [consul-cluster example](/examples/consul-cluster)), which is OK
+`assign_public_ip_addresses` set to `true` (as in the [consul-cluster example](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-cluster)), which is OK
 for testing and experimentation, but NOT recommended for production usage.
 
 To use the HTTP API, you first need to get the public IP address of one of the Consul Servers. You can find Consul 
-servers by using Compute Instance tags. If you're running the [consul-cluster example](/examples/consul-cluster), the 
-[consul-examples-helper.sh script](/examples/consul-examples-helper/consul-examples-helper.sh) will do the tag lookup 
+servers by using Compute Instance tags. If you're running the [consul-cluster example](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-cluster), the 
+[consul-examples-helper.sh script](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-examples-helper/consul-examples-helper.sh) will do the tag lookup 
 for you automatically (note, you must have the [Google Cloud SDK](https://cloud.google.com/sdk/) and the 
 [Consul agent](https://www.consul.io/) installed locally):
 
@@ -116,7 +116,7 @@ bar
 
 Finally, you can try opening up the Consul UI in your browser at the URL `http://11.22.33.44:8500/ui/`.
 
-![Consul UI](/_docs/consul-ui-screenshot.png)
+![Consul UI](https://github.com/gruntwork-io/terraform-google-consul/_docs/consul-ui-screenshot.png)
 
 
 ### Using the Consul agent on another Compute Instance
@@ -161,7 +161,7 @@ entries).
 
 This module creates the following architecture:
 
-![Consul architecture](/_docs/architecture.png)
+![Consul architecture](https://github.com/gruntwork-io/terraform-google-consul/_docs/architecture.png)
 
 This architecture consists of the following resources:
 
@@ -177,7 +177,7 @@ https://cloud.google.com/compute/docs/regions-zones/regions-zones). Unfortunatel
 https://github.com/terraform-providers/terraform-provider-google/issues/45), Managed Instance Groups can only be deployed
 to a single Zone, not across a Region.
 
-Each of the Compute Instances should be running a Google Image that has Consul installed via the [install-consul](/modules/install-consul)
+Each of the Compute Instances should be running a Google Image that has Consul installed via the [install-consul](https://github.com/gruntwork-io/terraform-google-consul/modules/install-consul)
 module. You pass in the name of the Image to run using the `source_image` input parameter.
 
 #### Compute Instance Tags
@@ -245,7 +245,7 @@ Here are some of the main security considerations to keep in mind when using thi
 ### Encryption in transit
 
 Consul can encrypt all of its network traffic. For instructions on enabling network encryption, have a look at the
-[How do you handle encryption documentation](/modules/run-consul#how-do-you-handle-encryption).
+[How do you handle encryption documentation](https://github.com/gruntwork-io/terraform-google-consul/modules/run-consul#how-do-you-handle-encryption).
 
 
 ### Encryption at rest

--- a/modules/install-consul/README.md
+++ b/modules/install-consul/README.md
@@ -1,9 +1,9 @@
 # Consul Install Script
 
 This folder contains a script for installing Consul and its dependencies. Use this script along with the
-[run-consul script](/modules/run-consul) to create a Consul [Google Image](https://cloud.google.com/compute/docs/images)
+[run-consul script](https://github.com/gruntwork-io/terraform-google-consul/modules/run-consul) to create a Consul [Google Image](https://cloud.google.com/compute/docs/images)
 that can be deployed in [GCP](https://cloud.google.com) across a Managed Instance Scaling Group using the 
-[consul-cluster module](/modules/consul-cluster).
+[consul-cluster module](https://github.com/gruntwork-io/terraform-google-consul/modules/consul-cluster).
 
 This script has been tested on the following operating systems:
 
@@ -17,7 +17,7 @@ There is a good chance it will work on other flavors of Debian as well.
 
 <!-- TODO: update the clone URL to the final URL when this Module is released -->
 
-To install Consul, use `git` to clone this repository at a specific tag (see the [releases page](../../../../releases) 
+To install Consul, use `git` to clone this repository at a specific tag (see the [releases page](https://github.com/gruntwork-io/terraform-google-consul/releases) 
 for all available tags) and run the `install-consul` script:
 
 ```
@@ -25,14 +25,14 @@ git clone --branch <VERSION> https://github.com/gruntwork-io/consul-gcp-module.g
 consul-gcp-module/modules/install-consul/install-consul --version 0.9.2
 ```
 
-The `install-consul` script will install Consul, its dependencies, and the [run-consul script](/modules/run-consul).
+The `install-consul` script will install Consul, its dependencies, and the [run-consul script](https://github.com/gruntwork-io/terraform-google-consul/modules/run-consul).
 The `run-consul` script is also run when the server is booting to start Consul and configure it to automatically 
 join other nodes to form a cluster.
 
 We recommend running the `install-consul` script as part of a [Packer](https://www.packer.io/) template to create a
-Consul [Image](https://cloud.google.com/compute/docs/images) (see the [consul-image example](/examples/consul-image) for
+Consul [Image](https://cloud.google.com/compute/docs/images) (see the [consul-image example](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-image) for
 fully-working sample code). You can then deploy the Image across a Managed Instance Group using the [consul-cluster
-module](/modules/consul-cluster) (see the [consul-cluster example](/examples/consul-cluster) for fully-working sample code).
+module](https://github.com/gruntwork-io/terraform-google-consul/modules/consul-cluster) (see the [consul-cluster example](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-cluster) for fully-working sample code).
 
 
 
@@ -81,7 +81,7 @@ Install the following:
 * `consul`: Download the Consul zip file from the [downloads page](https://www.consul.io/downloads.html) (the version 
   number is configurable via the `--version` argument), and extract the `consul` binary into `/opt/consul/bin`. Add a
   symlink to the `consul` binary in `/usr/local/bin`.
-* `run-consul`: Copy the [run-consul script](/modules/run-consul) into `/opt/consul/bin`. 
+* `run-consul`: Copy the [run-consul script](https://github.com/gruntwork-io/terraform-google-consul/modules/run-consul) into `/opt/consul/bin`. 
 
 
 ### Install supervisord

--- a/modules/install-dnsmasq/README.md
+++ b/modules/install-dnsmasq/README.md
@@ -17,7 +17,7 @@ There is a good chance it will work on other flavors of Debian as well.
 
 ## Quick start
 
-To install Dnsmasq, use `git` to clone this repository at a specific tag (see the [releases page](../../../../releases) 
+To install Dnsmasq, use `git` to clone this repository at a specific tag (see the [releases page](https://github.com/gruntwork-io/terraform-google-consul/releases) 
 for all available tags) and run the `install-dnsmasq` script:
 
 ```
@@ -34,7 +34,7 @@ dig foo.service.consul
 ```
 
 We recommend running the `install-dnsmasq` script as part of a [Packer](https://www.packer.io/) template to create a
-[Google Image](https://cloud.google.com/compute/docs/images) (see the [consul-image example](/examples/consul-image) for
+[Google Image](https://cloud.google.com/compute/docs/images) (see the [consul-image example](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-image) for
 sample code). 
 
 

--- a/modules/run-consul/README.md
+++ b/modules/run-consul/README.md
@@ -13,7 +13,7 @@ There is a good chance it will work on other flavors of Debian as well.
 ## Quick start
 
 This script assumes you installed it, plus all of its dependencies (including Consul itself), using the [install-consul 
-module](/modules/install-consul). The default install path is `/opt/consul/bin`, so to start Consul in server mode, 
+module](https://github.com/gruntwork-io/terraform-google-consul/modules/install-consul). The default install path is `/opt/consul/bin`, so to start Consul in server mode, 
 you run:
 
 ```
@@ -42,7 +42,7 @@ We recommend using the `run-consul` command as part of the [Startup Script](http
 so that it executes when the Compute Instance is first booting. After runing `run-consul` on that initial boot, the `supervisord`
 configuration  will automatically restart Consul if it crashes or the Compute instance reboots.
 
-See the [consul-cluster example](/examples/consul-cluster) for fully-working sample code.
+See the [consul-cluster example](https://github.com/gruntwork-io/terraform-google-consul/examples/consul-cluster) for fully-working sample code.
 
 
 


### PR DESCRIPTION
Per the new Terraform module standards, all README links are now absolute. If this repo URL changes in the future, we can simply do a global search-and-replace to update the URLs.

'cc @KFishner 